### PR TITLE
Update li with .alert

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -139,3 +139,7 @@ li .alert {
 	padding: 5px;
 	display: inline-block;
 }
+
+li:has(> .alert) {
+	list-style: none;
+}


### PR DESCRIPTION
Don't show "li" bullet in lines where info/alert is.